### PR TITLE
:bug: fix: cpf and cnpj validation and usertype mapping

### DIFF
--- a/src/main/java/com/picpay/project/service/impl/UsuarioServiceImpl.java
+++ b/src/main/java/com/picpay/project/service/impl/UsuarioServiceImpl.java
@@ -32,18 +32,25 @@ public class UsuarioServiceImpl implements UsuarioService {
 
     @Override
     public UsuarioDTO criarUsuario(UsuarioDTO dto) {
+        validaDocumento(dto);
         Usuario usuario = usuarioMapper.usuarioDtoParaUsuario(dto);
-        //validaDocumento(dto);
         Usuario usuarioSalvo = usuarioRepository.save(usuario);
         return usuarioMapper.usuarioParaUsuarioDto(usuarioSalvo);
     }
 
     @Override
     public void validaDocumento(UsuarioDTO dto) {
+        // Passo 1: instancia os objetos de validação
         CPFValidator cpfValidator = new CPFValidator();
         CNPJValidator cnpjValidator = new CNPJValidator();
+
+        // Passo 2: inicializa a constraintAnnotation, setando índices e parâmetros das validações
+        cpfValidator.initialize(null);
+        cnpjValidator.initialize(null);
+
         String documento = String.valueOf(dto.getDocumento());
 
+        // Passo 3: Efetua a validação em si
         if (documento != null) {
             if (cpfValidator.isValid(documento, null)) {
                 dto.setTipoUsuario(USUARIO_COMUM);


### PR DESCRIPTION
Este pull request está fazendo as seguintes alterações na classe UsuarioServiceImpl:

1. Invoca o método initialize(null) através dos objetos cpfValidator e cnpjValidator, para que a constraintAnnotation seja inicializada corretamente com a definição de seus parâmetros e índices (a falta dessa inicialização estava fazendo com que parâmetros para a validação não fossem definidos, de modo a estourar exceções). Referência 1 [(doc oficial)](https://docs.jboss.org/hibernate/validator/6.0/api/org/hibernate/validator/internal/constraintvalidators/hv/br/CPFValidator.html); Referência 2 [(code snippet das implementações dos métodos initialize())](https://gist.github.com/giovicente/bfe2295584dc4fbc0a9fe9cc713f1a03)
2. Chama o método validaDocumento(dto) antes do Mapper de DTO para Usuario, de modo que o campo TipoUsuario seja contemplado no Mapper dado que ele é setado no método validaDocumento(dto)

Desta forma, o mapeamento é realizado com sucesso e a validação ocorre conforme desejado, através da lib de validação do próprio Hibernate. A senha ainda é retornada nula por conta da notação `@JsonIgnore`.